### PR TITLE
Rewrote the backfill with a CTE and row_number() so duplicate metadat…

### DIFF
--- a/supabase/migrations/202604201130_profiles_auth_trigger.sql
+++ b/supabase/migrations/202604201130_profiles_auth_trigger.sql
@@ -1,3 +1,47 @@
+create or replace function public.resolve_profile_username(
+    preferred_username text,
+    profile_id uuid
+)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    base_username text := nullif(trim(coalesce(preferred_username, '')), '');
+    id_suffix text := left(replace(profile_id::text, '-', ''), 8);
+    candidate_username text;
+    suffix_counter integer := 0;
+begin
+    if base_username is null then
+        return null;
+    end if;
+
+    if not exists (
+        select 1
+        from public.profiles
+        where username = base_username
+            and id <> profile_id
+    ) then
+        return base_username;
+    end if;
+
+    candidate_username := base_username || '-' || id_suffix;
+
+    while exists (
+        select 1
+        from public.profiles
+        where username = candidate_username
+            and id <> profile_id
+    ) loop
+        suffix_counter := suffix_counter + 1;
+        candidate_username := base_username || '-' || id_suffix || '-' || suffix_counter::text;
+    end loop;
+
+    return candidate_username;
+end;
+$$;
+
 create or replace function public.handle_new_user_profile()
 returns trigger
 language plpgsql
@@ -8,12 +52,15 @@ begin
     insert into public.profiles (id, username, country)
     values (
         new.id,
-        nullif(trim(coalesce(new.raw_user_meta_data ->> 'username', '')), ''),
+        public.resolve_profile_username(new.raw_user_meta_data ->> 'username', new.id),
         nullif(trim(coalesce(new.raw_user_meta_data ->> 'country', '')), '')
     )
     on conflict (id) do update
     set
-        username = coalesce(excluded.username, public.profiles.username),
+        username = coalesce(
+            public.resolve_profile_username(excluded.username, public.profiles.id),
+            public.profiles.username
+        ),
         country = coalesce(excluded.country, public.profiles.country);
 
     return new;
@@ -26,15 +73,41 @@ after insert on auth.users
 for each row
 execute function public.handle_new_user_profile();
 
+with profile_backfill_candidates as (
+    select
+        users.id,
+        nullif(trim(coalesce(users.raw_user_meta_data ->> 'username', '')), '') as requested_username,
+        nullif(trim(coalesce(users.raw_user_meta_data ->> 'country', '')), '') as country
+    from auth.users as users
+    left join public.profiles as profiles
+        on profiles.id = users.id
+    where profiles.id is null
+),
+ranked_profile_backfill_candidates as (
+    select
+        id,
+        requested_username,
+        country,
+        row_number() over (
+            partition by requested_username
+            order by id
+        ) as username_rank
+    from profile_backfill_candidates
+)
 insert into public.profiles (id, username, country)
 select
-    users.id,
-    nullif(trim(coalesce(users.raw_user_meta_data ->> 'username', '')), ''),
-    nullif(trim(coalesce(users.raw_user_meta_data ->> 'country', '')), '')
-from auth.users as users
-left join public.profiles as profiles
-    on profiles.id = users.id
-where profiles.id is null;
+    id,
+    public.resolve_profile_username(
+        case
+            when requested_username is null then null
+            when username_rank = 1 then requested_username
+            else requested_username || '-' || left(replace(id::text, '-', ''), 8)
+        end,
+        id
+    ),
+    country
+from ranked_profile_backfill_candidates
+on conflict do nothing;
 
 alter table public.profiles enable row level security;
 


### PR DESCRIPTION
…a usernames get a suffix from the user UUID.

Added ON CONFLICT DO NOTHING as a final safety net so the migration will not crash on remaining unique conflicts.